### PR TITLE
include setupFn in the mixin

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -510,6 +510,7 @@ Options.prototype.mixin = function (source) {
   this._mixin(source._jsonSchema, this._jsonSchema)
   this._mixin(source._cookies, this._cookies)
 
+  if (source._setupFn) this._setupFn = source._setupFn
   if (source._payload) this._payload = source._payload
   if (source._xssiPrefix) this._xssiPrefix = source._xssiPrefix
   if (source._httpMethod) this._httpMethod = source._httpMethod

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falkor",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "keywords": [
     "javascript",
     "nodeunit",

--- a/tests/falkor_test.js
+++ b/tests/falkor_test.js
@@ -506,7 +506,12 @@ exports.testTemplateOverrides = function (test) {
 
 
 exports.testMixin = function (test) {
+  var setupValue = 0
+  var setupFunction = function () {
+    setupValue = 1
+  }
   var template1 = falkor.newTestTemplate()
+      .usingSetup(setupFunction)
       .withMethod('put')
       .withHeader('TestHeader', '1234')
       .withPayload('data')
@@ -516,6 +521,7 @@ exports.testMixin = function (test) {
       .expectBodyMatches(/result/)
 
   var mockTest = newMockTest(function (assertions) {
+    test.equals(1, setupValue, 'The setup function should have executed')
     test.equals(2, assertions.length, 'There should have been two assertions')
     test.equals('prefix=prefix', assertions[0].value, 'First assertion should have checked prefix')
     test.equals('ok', assertions[1].type, '2nd assertion should have been "ok"')


### PR DESCRIPTION
Hello @kylehg, 

Please review the following commits I made in branch 'mikkot-mixin-setup'.

Wasn't sure if this requires a version bump - let me know what you think 
or if there's conventions/rules to govern that.

ebf6791b8356d5766cffa9e567192692314e8734 (2016-03-28 10:54:57 -0700)
include setupFn in the mixin

R=@kylehg