### PR TITLE
Fix a bug in falkor where it sometimes didn't propagate asserts correctly inside then().

### DIFF
--- a/lib/testcase.js
+++ b/lib/testcase.js
@@ -97,6 +97,7 @@ TestCase.prototype.toNodeUnitFn = function () {
     testCase.done()
   }
   fn.isTestCaseNodeUnitFn = true
+  fn.testCase = testCase
 
   // We expose each public method on the TestCase through a method on the test function. This allows
   // for convenient chaining without a final 'build' call.
@@ -195,7 +196,7 @@ TestCase.prototype._run = function () {
 
   var promise = setupPromise.then(requestFunction)
 
-  return  (this._timeoutMs > 0) ? promise.timeout(this._timeoutMs) : promise
+  return (this._timeoutMs > 0) ? promise.timeout(this._timeoutMs) : promise
 }
 
 
@@ -252,7 +253,10 @@ TestCase.prototype._finalize = function (defer, res) {
       var result = chain.call(this, value)
 
       // If the result is a test case, propagate the asserter and run the promise.
-      if (result && (result instanceof TestCase || result.isTestCaseNodeUnitFn)) {
+      if (result && result.isTestCaseNodeUnitFn) {
+        result = result.testCase
+      }
+      if (result && (result instanceof TestCase)) {
         result.setAsserter(this._asserter)
         return result._run()
       } else {


### PR DESCRIPTION
Hello @ikai, 

Please review the following commits I made in branch 'nicks/promises'.

bc41e543bd42f18aa837c821579ab7be619a6575 (2017-02-06 14:56:39 -0500)
Fix a bug in falkor where it sometimes didn't propagate asserts correctly inside then().
This means that if the test threw an error, sometimes it would just hang forever instead of
reporting the error correctly.

R=@ikai